### PR TITLE
Router

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,7 @@ name: GitHub Pages Deployment
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches: ["router"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,7 @@ name: GitHub Pages Deployment
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["router"]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.6",
+        "react-router-dom": "^6.23.0",
         "sass": "^1.75.0",
         "styled-components": "^5.3.11",
         "vite": "^5.2.0",
@@ -2601,6 +2602,15 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.4.1.tgz",
       "integrity": "sha512-1MBMy92urkxoIy3qQecs6DzSgtVg9WElUhPXZ7GejqH8AmoakP6uMZGO1vyf0Cf9dBujqb0C+cXyZTTBLHWs0A=="
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.0.tgz",
+      "integrity": "sha512-Quz1KOffeEf/zwkCBM3kBtH4ZoZ+pT3xIXBG4PPW/XFtDP7EGhtTiC2+gpL9GnR7+Qdet5Oa6cYSvwKYg6kN9Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.15.0",
@@ -6526,6 +6536,38 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.0.tgz",
+      "integrity": "sha512-wPMZ8S2TuPadH0sF5irFGjkNLIcRvOSaEe7v+JER8508dyJumm6XZB1u5kztlX0RVq6AzRVndzqcUh6sFIauzA==",
+      "dev": true,
+      "dependencies": {
+        "@remix-run/router": "1.16.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.0.tgz",
+      "integrity": "sha512-Q9YaSYvubwgbal2c9DJKfx6hTNoBp3iJDsl+Duva/DwxoJH+OTXkxGpql4iUK2sla/8z4RpjAm6EWx1qUDuopQ==",
+      "dev": true,
+      "dependencies": {
+        "@remix-run/router": "1.16.0",
+        "react-router": "6.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-usestateref": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
+    "react-router-dom": "^6.23.0",
     "sass": "^1.75.0",
     "styled-components": "^5.3.11",
     "vite": "^5.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { HashRouter } from 'react-router-dom';
 import { ThemeProvider, BaseStyles, SplitPageLayout } from '@primer/react';
 import MenuList from './components/MenuList';
 import MainContent from './components/MainContent';
@@ -69,25 +70,26 @@ function App() {
         <FixedHeader />
         {showMobileMenu && <MobileMenu />}
         {!showMobileMenu &&
-          <SplitPageLayout sx={{marginTop: HEADER_LAYOUT_GAP}}>
-            <SplitPageLayout.Content sx={{paddingTop: '0.5rem'}}>
-              <MainContent />
-              {/* <Pagination pageCount={3} currentPage={1} showPages={{ narrow: false }}/> */}
-            </SplitPageLayout.Content>
-            <SplitPageLayout.Pane
-                id='menu'
-                resizable='true' 
-                aria-labelledby='menu' 
-                position='start' 
-                hidden={{ narrow: true }}
-            >
-              <MenuList />
-            </SplitPageLayout.Pane>
-            <SplitPageLayout.Footer>
-              Footer
-              {/* <ProgressSection /> */}
-            </SplitPageLayout.Footer>
-          </SplitPageLayout>
+          <HashRouter>
+            <SplitPageLayout sx={{marginTop: HEADER_LAYOUT_GAP}}>
+              <SplitPageLayout.Content sx={{paddingTop: '0.5rem'}}>
+                <MainContent />
+              </SplitPageLayout.Content>
+              <SplitPageLayout.Pane
+                  id='menu'
+                  resizable='true' 
+                  aria-labelledby='menu' 
+                  position='start' 
+                  hidden={{ narrow: true }}
+              >
+                <MenuList />
+              </SplitPageLayout.Pane>
+              <SplitPageLayout.Footer>
+                Footer
+                {/* <ProgressSection /> */}
+              </SplitPageLayout.Footer>
+            </SplitPageLayout>
+          </HashRouter>
         }
       </BaseStyles>
     </ThemeProvider>

--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Routes, Route } from 'react-router-dom';
 import GettingStarted from '../pages/GettingStarted';
 import Degree from '../pages/Degree';
 import BoostProfile from '../pages/BoostProfile';
@@ -9,21 +10,18 @@ function MainContent() {
 
   /* Listen for changes in url and save new href */
   useEffect(() => {
-    const updatePageRef = (path) => {
-      console.log('heard a change in url with: ');
-      console.log('pathname: ', path);
+    const updatePageRef = () => {
       console.log('query full url: ', window.location);
-      setPageRef(window.location.pathname);
     } 
-    window.addEventListener('popstate', () => updatePageRef(window.location.pathname));
+    window.addEventListener('popstate', () => updatePageRef());
   });
 
   return (
-    <>
-      { pageRef === '/' && <GettingStarted /> }
-      { pageRef === '/#choose-degree' && <Degree /> }
-      { pageRef === '/#boost-profile' && <BoostProfile /> }
-    </>
+    <Routes>
+      <Route path='/' element={<GettingStarted />} />
+      <Route path='/choose-degree' element={<Degree />} />
+      <Route path='/boost-profile' element={<BoostProfile />} />
+    </Routes>
   )
 }
 

--- a/src/components/MenuList.jsx
+++ b/src/components/MenuList.jsx
@@ -1,5 +1,6 @@
-import { NavList } from '@primer/react';
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { NavList } from '@primer/react';
 /* Icons from https://primer.style/foundations/icons */
 import { MegaphoneIcon, PasteIcon, CodeOfConductIcon, SunIcon, UnverifiedIcon, TableIcon,
          ProjectRoadmapIcon, MentionIcon,
@@ -36,7 +37,6 @@ function MenuList() {
   return (
     <NavList>
       <NavList.Item
-        href={pageOrigin + LandingPage[0].ref}
         aria-current={pageRef === LandingPage[0].ref ? 'page' : 'false'}
       >
         <NavList.LeadingVisual>
@@ -66,21 +66,23 @@ function MenuList() {
       </NavList.Group>
       <NavList.Group title='Application'>
         {ApplicationPages.map((page, index) => (
-          <NavList.Item 
-            key={index}
-            href={pageOrigin + page.ref} 
-            aria-current={pageRef === page.ref ? 'page' : 'false'}
-          >
-            <NavList.LeadingVisual>
-              {/* Using page pos => icon mapping to render icon */}
-              {renderPageIcon(page.pos)}
-            </NavList.LeadingVisual>
+          <Link to={page.ref} key={index}>
+            <NavList.Item 
+              key={index}
+              href={pageOrigin + page.ref} 
+              aria-current={pageRef === page.ref ? 'page' : 'false'}
+            >
+              <NavList.LeadingVisual>
+                {/* Using page pos => icon mapping to render icon */}
+                {renderPageIcon(page.pos)}
+              </NavList.LeadingVisual>
               {page.name}
-            {/* Using page pos => status mapping to render icon */}
-            {/* <NavList.TrailingVisual>
-              {renderStatusIcon(statusIdx[page.pos])}
-            </NavList.TrailingVisual> */}
-          </NavList.Item>
+              {/* Using page pos => status mapping to render icon */}
+              {/* <NavList.TrailingVisual>
+                {renderStatusIcon(statusIdx[page.pos])}
+              </NavList.TrailingVisual> */}
+            </NavList.Item>
+          </Link>
         ))}
       </NavList.Group>
       <NavList.Group title="Post-Application">
@@ -151,6 +153,7 @@ function MenuList() {
           </NavList.LeadingVisual>
           Build Good Habits
         </NavList.Item>
+        <Link to={`/projects`}>Wow</Link>
       </NavList.Group>
     </NavList>
   )


### PR DESCRIPTION
Vite server does not allow us to intercept html requests in production. This means that every url change that occurs with NavList.Item results in a 404 error (other than default '/'). It expects an html page per item but we want to use the same index.html across all. Nothing with Vite is working. 

So try to switch to React Router. We've set up specific routes for each of the NavList items. Currently trying to have NavList.Item set url to `/#/<nav-list-item>` because that's what Link usually does for the React Router. Hopefully the Router will hear this change properly and help keep the same index.html file but serve up different components.